### PR TITLE
Add license to manifest for future source bundles

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 global-exclude tests/*
 recursive-exclude tests *
 recursive-exclude tests_py35 *
+include LICENSE


### PR DESCRIPTION
Hey-lo,

I'm [building a version](https://github.com/conda-forge/staged-recipes/pull/3013) of `graphql-relay` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

This pull should update the manifest so that the license is included in future builds.