### PR TITLE
Fix pagination indicators when using list slices

### DIFF
--- a/graphql_relay/connection/arrayconnection.py
+++ b/graphql_relay/connection/arrayconnection.py
@@ -93,16 +93,14 @@ def connection_from_list_slice(list_slice, args=None, connection_type=None,
 
     first_edge_cursor = edges[0].cursor if edges else None
     last_edge_cursor = edges[-1].cursor if edges else None
-    lower_bound = after_offset + 1 if after else 0
-    upper_bound = before_offset if before else list_length
 
     return connection_type(
         edges=edges,
         page_info=pageinfo_type(
             start_cursor=first_edge_cursor,
             end_cursor=last_edge_cursor,
-            has_previous_page=isinstance(last, int) and start_offset > lower_bound,
-            has_next_page=isinstance(first, int) and end_offset < upper_bound
+            has_previous_page=start_offset > 0,
+            has_next_page=end_offset < list_length
         )
     )
 


### PR DESCRIPTION
According to the spec, `hasNextPage` and `hasPreviousPage` should be set regardless of the pagination direction if they can be efficiently computed.

Fixes #12 