### PR TITLE
Adding support for limiting array length and updated next/previous logic

### DIFF
--- a/graphql_relay/connection/arrayconnection.py
+++ b/graphql_relay/connection/arrayconnection.py
@@ -31,7 +31,7 @@ def connection_from_promised_list(data_promise, args=None, **kwargs):
 
 def connection_from_list_slice(list_slice, args=None, connection_type=None,
                                edge_type=None, pageinfo_type=None,
-                               slice_start=0, list_length=0, list_slice_length=None):
+                               slice_start=0, list_length=0, list_slice_length=None, limit=None):
     '''
     Given a slice (subset) of an array, returns a connection object for use in
     GraphQL.
@@ -77,11 +77,13 @@ def connection_from_list_slice(list_slice, args=None, connection_type=None,
             end_offset - last
         )
 
+    _start = max(start_offset - slice_start, 0)
+    _finish = list_slice_length - (slice_end - end_offset)
+    if limit and _finish - _start > limit:
+        _finish = _start + limit
+
     # If supplied slice is too large, trim it down before mapping over it.
-    _slice = list_slice[
-        max(start_offset - slice_start, 0):
-        list_slice_length - (slice_end - end_offset)
-    ]
+    _slice = list_slice[_start:_finish]
     edges = [
         edge_type(
             node=node,
@@ -93,16 +95,14 @@ def connection_from_list_slice(list_slice, args=None, connection_type=None,
 
     first_edge_cursor = edges[0].cursor if edges else None
     last_edge_cursor = edges[-1].cursor if edges else None
-    lower_bound = after_offset + 1 if after else 0
-    upper_bound = before_offset if before else list_length
 
     return connection_type(
         edges=edges,
         page_info=pageinfo_type(
             start_cursor=first_edge_cursor,
             end_cursor=last_edge_cursor,
-            has_previous_page=isinstance(last, int) and start_offset > lower_bound,
-            has_next_page=isinstance(first, int) and end_offset < upper_bound
+            has_previous_page= _start > 0,
+            has_next_page= _finish < list_slice_length
         )
     )
 


### PR DESCRIPTION
It is possible to trivially add support for limiting the size of a return object. This is important because people might ask for 10,000 items and we need to enforce a hard limit on the number of items.

From my understanding, the relay spec has also been modified to allow better handling of the hasPreviousPage/hasNextPage logic, https://github.com/facebook/relay/pull/2079.

Since we have just a list here, it is very simple to have more accurate hasPreviousPage and hasNextPage logic. Should make it easier to support windowed pagination.