### PR TITLE
Pin graphql-core to <2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
+  - 3.6
+  - 3.7
   - pypy3
 install:
   - pip install pytest pytest-cov flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: python
-sudo: false
+dist: xenial
+
 python:
-- 2.7
-- 3.3
-- 3.4
-- 3.5
-- pypy
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy3
 install:
-- pip install pytest pytest-cov coveralls flake8
-- pip install .
+  - pip install pytest pytest-cov flake8
+  - pip install .
 script:
-- py.test --cov=graphql_relay
+  - py.test --cov=graphql_relay
 # - flake8
 after_success:
-- coveralls
+  - pip install coveralls
+  - coveralls

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphql-core>=0.5.0',
+        'graphql-core>=0.5.0,<1',
         'promise>=0.4.0'
     ],
     tests_require=['pytest>=2.7.2'],

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphql-core>=0.5.0,<1',
+        'graphql-core>=0.5.0,<2',
         'promise>=0.4.0'
     ],
     tests_require=['pytest>=2.7.2'],


### PR DESCRIPTION
Part of https://github.com/graphql-python/graphql-core/issues/249

This PR just pins graphql-core to use versions less than v2 since the code hasn't been updated to support v2. Support for v2 will come in a later PR.

(The travis config has also been updated to fix a build failure and run against more recent versions of python)