### PR TITLE
[DNM] Revert graphql-core upper version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class PyTest(TestCommand):
 
 setup(
     name='graphql-relay',
-    version='0.4.5',
+    version='0.4.6',
 
     description='Relay implementation for Python',
     long_description=open('README.rst').read(),

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphql-core>=0.5.0,<2',
+        'graphql-core>=0.5.0',
         'promise>=0.4.0'
     ],
     tests_require=['pytest>=2.7.2'],


### PR DESCRIPTION
https://github.com/graphql-python/graphql-relay-py/issues/23

The incorrect wheel was uploaded to v0.4.5. Since we cannot delete the incorrect wheel from PyPI we're releasing a new minor version without the pinned restriction on graphql-core.

*Not for merging, only for feedback*