### PR TITLE
Allow to pass any type

### DIFF
--- a/src/graphql_relay/node/node.py
+++ b/src/graphql_relay/node/node.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, NamedTuple
+from typing import Any, Callable, NamedTuple, Union
 
 from graphql_relay.utils.base64 import base64, unbase64
 
@@ -78,7 +78,7 @@ class ResolvedGlobalId(NamedTuple):
     id: str
 
 
-def to_global_id(type_: any, id_: str) -> str:
+def to_global_id(type_: any, id_: Union[str, int]) -> str:
     """
     Takes a type name and an ID specific to that type name, and returns a
     "global ID" that is unique among all types.

--- a/src/graphql_relay/node/node.py
+++ b/src/graphql_relay/node/node.py
@@ -78,7 +78,7 @@ class ResolvedGlobalId(NamedTuple):
     id: str
 
 
-def to_global_id(type_: str, id_: str) -> str:
+def to_global_id(type_: any, id_: str) -> str:
     """
     Takes a type name and an ID specific to that type name, and returns a
     "global ID" that is unique among all types.

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -309,6 +309,8 @@ def describe_convert_global_ids():
         g_id = to_global_id("MyType", my_unicode_id)
         assert g_id == "TXlUeXBlOtut"
 
+    def converts_to_global_id():
+        assert to_global_id("User", 1) == to_global_id("User", "1")
         assert to_global_id("User", 1) == to_global_id(user_type, 1)
 
     def from_global_id_converts_unicode_strings_correctly():

--- a/tests/node/test_node.py
+++ b/tests/node/test_node.py
@@ -309,6 +309,8 @@ def describe_convert_global_ids():
         g_id = to_global_id("MyType", my_unicode_id)
         assert g_id == "TXlUeXBlOtut"
 
+        assert to_global_id("User", 1) == to_global_id(user_type, 1)
+
     def from_global_id_converts_unicode_strings_correctly():
         my_unicode_id = "ûñö"
         my_type, my_id = from_global_id("TXlUeXBlOsO7w7HDtg==")


### PR DESCRIPTION
This PR allows to pass any type to `to_global_id`

Also, it allows passing int as ID (as well as in JS lib https://github.com/graphql/graphql-relay-js/blob/main/src/node/node.d.ts#L44)

@Cito What do you think?