### PR TITLE
Re-add deprecated module 'arrayconnection' for backwards compatibility

### DIFF
--- a/src/graphql_relay/connection/arrayconnection.py
+++ b/src/graphql_relay/connection/arrayconnection.py
@@ -1,0 +1,28 @@
+import warnings
+
+from .array_connection import (
+    connection_from_array,
+    connection_from_array_slice,
+    cursor_for_object_in_connection,
+    cursor_to_offset,
+    get_offset_with_default,
+    offset_to_cursor,
+)
+
+
+warnings.warn(
+    "The 'arrayconnection' module is deprecated. "
+    "Functions should be imported from the top-level package instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+__all__ = [
+    "connection_from_array",
+    "connection_from_array_slice",
+    "cursor_for_object_in_connection",
+    "cursor_to_offset",
+    "get_offset_with_default",
+    "offset_to_cursor",
+]


### PR DESCRIPTION
Adds back the `arrayconnection` module which simply exports the names from `array_connection`. This was necessary to maintain backwards compatibility with the previous versions.

Note: this should be removed after a major version increment.