### PR TITLE
Update typing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/src/graphql_relay/__init__.py
+++ b/src/graphql_relay/__init__.py
@@ -22,6 +22,7 @@ from .connection.connection import (
     PageInfo,
     PageInfoConstructor,
     PageInfoType,
+    Traversable,
 )
 
 # Helpers for creating connections from arrays
@@ -92,6 +93,7 @@ __all__ = [
     "plural_identifying_root_field",
     "ResolvedGlobalId",
     "SizedSliceable",
+    "Traversable",
     "to_global_id",
     "version",
     "version_info",

--- a/src/graphql_relay/connection/array_connection.py
+++ b/src/graphql_relay/connection/array_connection.py
@@ -1,9 +1,10 @@
-from typing import Any, Iterator, Optional, Sequence
+import sys
+from typing import Any, Iterator, Optional, overload, Sequence
 
-try:
-    from typing import Protocol
-except ImportError:  # Python < 3.8
-    from typing_extensions import Protocol  # type: ignore
+if sys.version_info >= (3, 8):
+    from typing import Protocol  # pragma: no cover
+else:
+    from typing_extensions import Protocol  # pragma: no cover
 
 from ..utils.base64 import base64, unbase64
 from .connection import (
@@ -11,7 +12,6 @@ from .connection import (
     ConnectionArguments,
     ConnectionConstructor,
     ConnectionCursor,
-    ConnectionType,
     Edge,
     EdgeConstructor,
     PageInfo,
@@ -33,11 +33,45 @@ class SizedSliceable(Protocol):
     def __getitem__(self, index: slice) -> Any:
         ...
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[Any]:
         ...
 
     def __len__(self) -> int:
         ...
+
+
+@overload
+def connection_from_array(
+    data: SizedSliceable,
+    args: Optional[ConnectionArguments] = None,
+    *,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Connection:
+    ...
+
+
+@overload
+def connection_from_array(
+    data: SizedSliceable,
+    args: Optional[ConnectionArguments],
+    connection_type: ConnectionConstructor,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Any:
+    ...
+
+
+@overload
+def connection_from_array(
+    data: SizedSliceable,
+    args: Optional[ConnectionArguments] = None,
+    *,
+    connection_type: ConnectionConstructor,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Any:
+    ...
 
 
 def connection_from_array(
@@ -46,7 +80,7 @@ def connection_from_array(
     connection_type: ConnectionConstructor = Connection,
     edge_type: EdgeConstructor = Edge,
     page_info_type: PageInfoConstructor = PageInfo,
-) -> ConnectionType:
+) -> Any:
     """Create a connection object from a sequence of objects.
 
     Note that different from its JavaScript counterpart which expects an array,
@@ -70,6 +104,49 @@ def connection_from_array(
     )
 
 
+@overload
+def connection_from_array_slice(
+    array_slice: SizedSliceable,
+    args: Optional[ConnectionArguments] = None,
+    slice_start: int = 0,
+    array_length: Optional[int] = None,
+    array_slice_length: Optional[int] = None,
+    *,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Connection:
+    ...
+
+
+@overload
+def connection_from_array_slice(
+    array_slice: SizedSliceable,
+    args: Optional[ConnectionArguments],
+    slice_start: int,
+    array_length: Optional[int],
+    array_slice_length: Optional[int],
+    connection_type: ConnectionConstructor,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Any:
+    ...
+
+
+@overload
+def connection_from_array_slice(
+    array_slice: SizedSliceable,
+    args: Optional[ConnectionArguments] = None,
+    slice_start: int = 0,
+    array_length: Optional[int] = None,
+    array_slice_length: Optional[int] = None,
+    *,
+    connection_type: ConnectionConstructor,
+    edge_type: EdgeConstructor = Edge,
+    page_info_type: PageInfoConstructor = PageInfo,
+) -> Any:
+    ...
+
+
 def connection_from_array_slice(
     array_slice: SizedSliceable,
     args: Optional[ConnectionArguments] = None,
@@ -79,7 +156,7 @@ def connection_from_array_slice(
     connection_type: ConnectionConstructor = Connection,
     edge_type: EdgeConstructor = Edge,
     page_info_type: PageInfoConstructor = PageInfo,
-) -> ConnectionType:
+) -> Any:
     """Create a connection object from a slice of the result set.
 
     Note that different from its JavaScript counterpart which expects an array,

--- a/src/graphql_relay/connection/connection.py
+++ b/src/graphql_relay/connection/connection.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 from graphql import (
@@ -18,10 +19,10 @@ from graphql import (
 
 from graphql import GraphQLNamedOutputType
 
-try:
-    from typing import Protocol
-except ImportError:  # Python < 3.8
-    from typing_extensions import Protocol  # type: ignore
+if sys.version_info >= (3, 8):
+    from typing import Protocol  # pragma: no cover
+else:
+    from typing_extensions import Protocol  # pragma: no cover
 
 __all__ = [
     "backward_connection_args",
@@ -41,6 +42,7 @@ __all__ = [
     "PageInfo",
     "PageInfoConstructor",
     "PageInfoType",
+    "Traversable",
 ]
 
 
@@ -152,12 +154,15 @@ class PageInfoType(Protocol):
     def startCursor(self) -> Optional[ConnectionCursor]:
         ...
 
+    @property
     def endCursor(self) -> Optional[ConnectionCursor]:
         ...
 
+    @property
     def hasPreviousPage(self) -> bool:
         ...
 
+    @property
     def hasNextPage(self) -> bool:
         ...
 
@@ -170,7 +175,7 @@ class PageInfoConstructor(Protocol):
         endCursor: Optional[ConnectionCursor],
         hasPreviousPage: bool,
         hasNextPage: bool,
-    ) -> PageInfoType:
+    ) -> Any:
         ...
 
 
@@ -183,18 +188,20 @@ class PageInfo(NamedTuple):
     hasNextPage: bool
 
 
-class EdgeType(Protocol):
-    @property
-    def node(self) -> Any:
-        ...
-
+class Traversable(Protocol):
     @property
     def cursor(self) -> ConnectionCursor:
         ...
 
 
+class EdgeType(Traversable, Protocol):
+    @property
+    def node(self) -> Any:
+        ...
+
+
 class EdgeConstructor(Protocol):
-    def __call__(self, *, node: Any, cursor: ConnectionCursor) -> EdgeType:
+    def __call__(self, *, node: Any, cursor: ConnectionCursor) -> Traversable:
         ...
 
 
@@ -219,9 +226,9 @@ class ConnectionConstructor(Protocol):
     def __call__(
         self,
         *,
-        edges: List[EdgeType],
-        pageInfo: PageInfoType,
-    ) -> ConnectionType:
+        edges: List[Any],
+        pageInfo: Any,
+    ) -> Any:
         ...
 
 

--- a/src/graphql_relay/mutation/mutation.py
+++ b/src/graphql_relay/mutation/mutation.py
@@ -80,7 +80,6 @@ def mutation_with_client_mutation_id(
     input_type = GraphQLInputObjectType(name + "Input", fields=augmented_input_fields)
 
     if iscoroutinefunction(mutate_and_get_payload):
-
         # noinspection PyShadowingBuiltins
         async def resolve(_root: Any, info: GraphQLResolveInfo, input: Dict) -> Any:
             payload = await mutate_and_get_payload(info, **input)
@@ -94,7 +93,6 @@ def mutation_with_client_mutation_id(
             return payload
 
     else:
-
         # noinspection PyShadowingBuiltins
         def resolve(  # type: ignore
             _root: Any, info: GraphQLResolveInfo, input: Dict

--- a/src/graphql_relay/node/node.py
+++ b/src/graphql_relay/node/node.py
@@ -24,7 +24,6 @@ __all__ = [
 
 
 class GraphQLNodeDefinitions(NamedTuple):
-
     node_interface: GraphQLInterfaceType
     node_field: GraphQLField
     nodes_field: GraphQLField
@@ -83,7 +82,6 @@ def node_definitions(
 
 
 class ResolvedGlobalId(NamedTuple):
-
     type: str
     id: str
 

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -19,7 +19,6 @@ from ..utils import dedent
 
 
 class Result:
-
     # noinspection PyPep8Naming
     def __init__(self, result, clientMutationId=None):
         self.clientMutationId = clientMutationId

--- a/tests/star_wars_schema.py
+++ b/tests/star_wars_schema.py
@@ -212,7 +212,6 @@ query_type = GraphQLObjectType(
 
 
 class IntroduceShipMutation:
-
     # noinspection PyPep8Naming
     def __init__(self, shipId, factionId, clientMutationId=None):
         self.shipId = shipId


### PR DESCRIPTION
The release of mypy 1.0 revealed some issues in the typing that I helped add previously:

1. The `PageInfoType` protocol is missing some `@property` decorators
2. The typing on the *Constructor protocols is overly restrictive.  It requires the return values to be of specific shapes, but actually these constructors should not be this strict.  For instance, one use case for the `PageInfoConstructor` is creating a class which uses snake_case instead of camelCase for the properties.  The implementation of `graphql-relay-py` library is not opinionated about this, so the typing should not be either.
3. The `connection_from_array` and `connection_from_array_slice` might not return a `ConnectionType`, due to 2 above.  So `@overload` variants are added here to more accurately match the behavior.

I've also added a `Traversable` protocol, which specifies and object with a `cursor` property.  This is the minimum requirement for the return of `EdgeConstructor`, since the code will crash without a `cursor`.

In addition, updating the Github workflows and black formatting here.

I spent some time attempting to make the typing much more accurate using generic parameters on the various protocols, but parameterized protocols [don't work properly](https://github.com/python/mypy/issues/14798) when applied to arguments at the moment.  Its also currently not possible with mypy to set a default value on an argument with a type variable due to [this issue](https://github.com/python/mypy/issues/3737), which makes the number of overloads explode.  Hopefully these problems will be resolved and the typing on `graphql-relay-py` can be further improved.